### PR TITLE
Fix property parsing for real values

### DIFF
--- a/aadllexer/lexer.py
+++ b/aadllexer/lexer.py
@@ -109,12 +109,12 @@ class AADLLexer(RegexLexer):
             (r';', Punctuation, '#pop:2'),
         ],
         'property-value' : [
-            (r'[0-9]+', Number.Integer),
             (r'(true|false)', Keyword.Constant),
             (r'\(', Punctuation),
             (r'\)', Punctuation),
             (r',', Punctuation),
             (r'[0-9]+\.[0-9]*', Number.Float),
+            (r'[0-9]+', Number.Integer),
             (r'(reference)(\s*)(\()(' + iden_rex + ')(\))',
              bygroups(Keyword.Declaration, Whitespace, Punctuation, Name.Variable.Instance, Punctuation)),
             (r'"[^"]*"', Literal.String.Double),


### PR DESCRIPTION
Integers were higher priority than reals in property value parsing, so 42.0 would get parsed as `<int>42</int><error>.</error><int>0</int>` instead of `<float>42.0</float>`